### PR TITLE
Add install scripts for Linux, macOS, and Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,28 @@
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'fluo10/tryluck'
+$InstallDir = Join-Path $HOME '.local\bin'
+
+$Response = Invoke-WebRequest -Uri "https://github.com/$Repo/releases/latest" -MaximumRedirection 0 -ErrorAction Ignore
+$Version = $Response.Headers.Location -replace '.*/tag/', ''
+if (-not $Version) {
+    Write-Error 'Failed to fetch latest version.'
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+$Asset = 'tryluck-windows-x86_64.exe'
+$Url = "https://github.com/$Repo/releases/download/$Version/$Asset"
+$Dest = Join-Path $InstallDir 'tryluck.exe'
+
+Write-Host "Installing tryluck $Version to $InstallDir..."
+Invoke-WebRequest -Uri $Url -OutFile $Dest
+Write-Host "Done! $Dest installed."
+
+$UserPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+if ($UserPath -notlike "*$InstallDir*") {
+    [Environment]::SetEnvironmentVariable('PATH', "$InstallDir;$UserPath", 'User')
+    Write-Host ""
+    Write-Host "Added $InstallDir to your PATH. Restart your terminal to apply."
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -eu
+
+REPO="fluo10/tryluck"
+INSTALL_DIR="${HOME}/.local/bin"
+
+case "$(uname -s)" in
+  Linux*)  OS="linux" ;;
+  Darwin*) OS="macos" ;;
+  *) echo "error: unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+  x86_64)        ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="aarch64" ;;
+  *) echo "error: unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+VERSION=$(curl -sfI "https://github.com/${REPO}/releases/latest" \
+  | awk '/^[Ll]ocation:/{print $2}' \
+  | tr -d '\r' \
+  | sed 's|.*/tag/||')
+
+if [ -z "$VERSION" ]; then
+  echo "error: failed to fetch latest version" >&2
+  exit 1
+fi
+
+mkdir -p "$INSTALL_DIR"
+
+ASSET="tryluck-${OS}-${ARCH}"
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
+
+printf "Installing tryluck %s (%s/%s) to %s...\n" "$VERSION" "$OS" "$ARCH" "$INSTALL_DIR"
+
+TMP=$(mktemp)
+curl -fsSL "$URL" -o "$TMP"
+chmod +x "$TMP"
+mv "$TMP" "${INSTALL_DIR}/tryluck"
+
+echo "Done! ${INSTALL_DIR}/tryluck installed."
+
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    printf "\nNote: %s is not in PATH. Add to your shell profile:\n" "$INSTALL_DIR"
+    printf '  export PATH="$HOME/.local/bin:$PATH"\n'
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Add `install.sh`: detects OS and architecture, downloads the matching binary from the latest GitHub Release, and installs it to `~/.local/bin`. Prints a PATH hint if the directory is not in `$PATH`.
- Add `install.ps1`: downloads the Windows binary from the latest GitHub Release and installs it to `%USERPROFILE%\.local\bin`. Adds the directory to the user PATH if not already present.

## Usage

**Unix (Linux / macOS):**
```sh
curl -fsSL https://raw.githubusercontent.com/fluo10/tryluck/main/install.sh | sh
```

**Windows (PowerShell):**
```powershell
irm https://raw.githubusercontent.com/fluo10/tryluck/main/install.ps1 | iex
```

## Test plan

- [ ] Run `install.sh` on Linux x86_64 and confirm `~/.local/bin/tryluck` is installed
- [ ] Run `install.sh` on Linux aarch64 and macOS and confirm correct binary is downloaded
- [ ] Run `install.ps1` on Windows and confirm `tryluck.exe` is installed and PATH is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)