### PR TITLE
Add tarot command and MCP tool for Major Arcana draws

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "rmcp",
  "schemars",
  "serde",
+ "serde_json",
  "tokio",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4", features = ["derive"] }
 rmcp = { version = "1.1", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 schemars = "1.0"
 anyhow = "1"
 tracing-subscriber = "0.3"

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -1,4 +1,5 @@
 use rand::RngExt as _;
+use crate::commands::tarot::{self, Case};
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -33,6 +34,14 @@ struct CoinParams {
     boolean: Option<bool>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct TarotParams {
+    /// Number of cards to draw (default: 1, max: 22)
+    count: Option<u32>,
+    /// Card name case: "snake" (default, e.g. "the_fool") or "proper" (e.g. "The Fool")
+    case: Option<String>,
+}
+
 // ── tool implementations ──────────────────────────────────────────────────────
 
 #[tool_router]
@@ -53,6 +62,17 @@ impl TryluckServer {
             .collect();
         rmcp::serde_json::to_string(&results).map_err(|e: rmcp::serde_json::Error| e.to_string())
     }
+
+    #[tool(description = "Draw one or more Major Arcana tarot cards. Returns a JSON array of objects with `card` (card name) and `orientation` (\"upright\" or \"reversed\") fields. Card names use snake_case by default (e.g. \"the_fool\"), or proper case when case=\"proper\".")]
+    fn tarot(&self, Parameters(p): Parameters<TarotParams>) -> Result<String, String> {
+        let count = p.count.unwrap_or(1);
+        let case = match p.case.as_deref() {
+            Some("proper") => Case::Proper,
+            _ => Case::Snake,
+        };
+        let draws = tarot::draw(count, case);
+        rmcp::serde_json::to_string(&draws).map_err(|e: rmcp::serde_json::Error| e.to_string())
+    }
 }
 
 #[tool_handler]
@@ -61,7 +81,8 @@ impl ServerHandler for TryluckServer {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(
                 "Tryluck provides randomization tools for TRPG and games. \
-                 Use coin to flip a coin."
+                 Use coin to flip a coin. \
+                 Use tarot to draw Major Arcana tarot cards."
                     .to_owned(),
             )
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod coin;
 pub mod mcp;
+pub mod tarot;

--- a/src/commands/tarot.rs
+++ b/src/commands/tarot.rs
@@ -1,0 +1,91 @@
+use rand::RngExt as _;
+use rand::seq::SliceRandom as _;
+use serde::Serialize;
+
+/// Output case format for card names.
+#[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Case {
+    /// Proper display name, e.g. "The Fool"
+    Proper,
+    /// Snake case identifier, e.g. "the_fool"
+    Snake,
+}
+
+struct Card {
+    snake: &'static str,
+    proper: &'static str,
+}
+
+impl Card {
+    fn format(&self, case: Case) -> &'static str {
+        match case {
+            Case::Proper => self.proper,
+            Case::Snake => self.snake,
+        }
+    }
+}
+
+const CARDS: &[Card] = &[
+    Card { snake: "the_fool",           proper: "The Fool"           },
+    Card { snake: "the_magician",       proper: "The Magician"       },
+    Card { snake: "the_high_priestess", proper: "The High Priestess" },
+    Card { snake: "the_empress",        proper: "The Empress"        },
+    Card { snake: "the_emperor",        proper: "The Emperor"        },
+    Card { snake: "the_hierophant",     proper: "The Hierophant"     },
+    Card { snake: "the_lovers",         proper: "The Lovers"         },
+    Card { snake: "the_chariot",        proper: "The Chariot"        },
+    Card { snake: "strength",           proper: "Strength"           },
+    Card { snake: "the_hermit",         proper: "The Hermit"         },
+    Card { snake: "wheel_of_fortune",   proper: "Wheel of Fortune"   },
+    Card { snake: "justice",            proper: "Justice"            },
+    Card { snake: "the_hanged_man",     proper: "The Hanged Man"     },
+    Card { snake: "death",              proper: "Death"              },
+    Card { snake: "temperance",         proper: "Temperance"         },
+    Card { snake: "the_devil",          proper: "The Devil"          },
+    Card { snake: "the_tower",          proper: "The Tower"          },
+    Card { snake: "the_star",           proper: "The Star"           },
+    Card { snake: "the_moon",           proper: "The Moon"           },
+    Card { snake: "the_sun",            proper: "The Sun"            },
+    Card { snake: "judgement",          proper: "Judgement"          },
+    Card { snake: "the_world",          proper: "The World"          },
+];
+
+#[derive(Debug, Serialize)]
+pub struct TarotDraw {
+    pub card: &'static str,
+    pub orientation: &'static str,
+}
+
+/// Draw `count` cards without replacement (capped at deck size).
+pub fn draw(count: u32, case: Case) -> Vec<TarotDraw> {
+    let mut rng = rand::rng();
+    let count = (count.max(1) as usize).min(CARDS.len());
+
+    let mut indices: Vec<usize> = (0..CARDS.len()).collect();
+    indices.shuffle(&mut rng);
+
+    indices[..count]
+        .iter()
+        .map(|&i| TarotDraw {
+            card: CARDS[i].format(case),
+            orientation: if rng.random_bool(0.5) { "upright" } else { "reversed" },
+        })
+        .collect()
+}
+
+pub fn run(count: u32, json: bool, case: Case) {
+    let draws = draw(count, case);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&draws).unwrap());
+    } else {
+        for d in &draws {
+            if d.orientation == "upright" {
+                println!("{}", d.card);
+            } else {
+                // Reversed cards are displayed as reversed characters
+                println!("{}", d.card.chars().rev().collect::<String>());
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,17 @@ enum Command {
         /// Number of flips (default: 1)
         count: Option<u32>,
     },
+    /// Draw tarot cards from the Major Arcana
+    Tarot {
+        /// Output as JSON array of {card, orientation} objects (defaults to snake case)
+        #[arg(long)]
+        json: bool,
+        /// Card name case format (default: proper for plain text, snake for --json)
+        #[arg(long, value_enum)]
+        case: Option<commands::tarot::Case>,
+        /// Number of cards to draw (default: 1)
+        count: Option<u32>,
+    },
     /// Start the MCP server (stdio transport)
     Mcp,
 }
@@ -30,6 +41,11 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Command::Coin { boolean, count } => commands::coin::run(count.unwrap_or(1), boolean),
+        Command::Tarot { json, case, count } => {
+            use commands::tarot::Case;
+            let case = case.unwrap_or(if json { Case::Snake } else { Case::Proper });
+            commands::tarot::run(count.unwrap_or(1), json, case)
+        }
         Command::Mcp => commands::mcp::run().await?,
     }
 


### PR DESCRIPTION
## Summary

- Implements `tryluck tarot [N]` CLI command that draws N cards (without replacement) from the 22 Major Arcana, each with a random upright/reversed orientation
- Adds `--json` flag for structured `{"card", "orientation"}` output aimed at AI/MCP consumers (defaults to snake_case card names for tokenizer friendliness)
- Adds `--case snake|proper` flag to control card name formatting in all output modes (plain text defaults to proper case, e.g. `The Fool`; `--json` defaults to snake_case, e.g. `the_fool`)
- Reversed cards in plain text mode are displayed as reversed characters (e.g. `looF ehT`), matching the existing CLI convention
- Exposes a `tarot` MCP tool returning the same structured JSON, snake_case by default with optional `case: "proper"` parameter

## Test plan

- [x] `tryluck tarot 3` — prints 3 unique Major Arcana cards in proper case; reversed cards appear as reversed text
- [x] `tryluck tarot 3 --case snake` — same but snake_case names
- [x] `tryluck tarot 3 --json` — JSON array with snake_case card names and `"upright"` / `"reversed"` orientations
- [x] `tryluck tarot 3 --json --case proper` — JSON array with proper-case card names
- [x] `tryluck tarot 22` — all 22 cards drawn, no duplicates
- [ ] MCP `tarot` tool — returns correct JSON via stdio transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)