### PR TITLE
Add --json flag to coin command

### DIFF
--- a/src/commands/coin.rs
+++ b/src/commands/coin.rs
@@ -1,12 +1,27 @@
 use rand::RngExt as _;
 
-pub fn run(count: u32, boolean: bool) {
-    for _ in 0..count {
-        let result = rand::rng().random_bool(0.5);
-        if boolean {
-            println!("{result}");
-        } else {
-            println!("{}", if result { "heads" } else { "tails" });
+pub fn run(count: u32, boolean: bool, json: bool) {
+    let mut rng = rand::rng();
+    if json {
+        let flips: Vec<&str> = (0..count)
+            .map(|_| {
+                let result = rng.random_bool(0.5);
+                if boolean {
+                    if result { "true" } else { "false" }
+                } else {
+                    if result { "heads" } else { "tails" }
+                }
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&flips).unwrap());
+    } else {
+        for _ in 0..count {
+            let result = rng.random_bool(0.5);
+            if boolean {
+                println!("{result}");
+            } else {
+                println!("{}", if result { "heads" } else { "tails" });
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,9 @@ struct Cli {
 enum Command {
     /// Flip a coin and print heads or tails
     Coin {
+        /// Output as JSON array of {result} objects
+        #[arg(long)]
+        json: bool,
         /// Output true/false instead of heads/tails
         #[arg(long)]
         boolean: bool,
@@ -40,7 +43,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Coin { boolean, count } => commands::coin::run(count.unwrap_or(1), boolean),
+        Command::Coin { json, boolean, count } => commands::coin::run(count.unwrap_or(1), boolean, json),
         Command::Tarot { json, case, count } => {
             use commands::tarot::Case;
             let case = case.unwrap_or(if json { Case::Snake } else { Case::Proper });


### PR DESCRIPTION
## Summary

- `tryluck coin --json` outputs a JSON string array (e.g. `["heads", "tails"]`)
- Combined with `--boolean`, outputs `["true", "false"]`
- Consistent with the MCP tool response format

## Test plan

- [x] `tryluck coin --json 3` → string array of `"heads"`/`"tails"`
- [x] `tryluck coin --json --boolean 3` → string array of `"true"`/`"false"`
- [x] `tryluck coin 3` (no flags) → unchanged plain text behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)